### PR TITLE
Adapt to Griffin MDM changes

### DIFF
--- a/profiles/griffin.nix
+++ b/profiles/griffin.nix
@@ -1,31 +1,9 @@
 { pkgs, ... }: {
-  networking.computerName = "Griffin";
-  networking.hostName = "griffin";
-
-  # TODO: applications installed through Nix are not findable
-  # through Spotlight. For now, use Homebrew to install them
-  # and work around this.
-  # environment.systemPackages = with pkgs; [
-  #   _1password
-  #   _1password-gui
-  #   docker
-  #   slack
-  # ];
-
   # For applications that aren't available in nixpkgs,
   # or not available for aarch64-darwin.
   # TODO: need to manually install homebrew.
   homebrew = {
     enable = true;
-    casks = [
-      "1password"
-      "1password-cli"
-      "docker"
-      "linear"
-      "notion"
-      "signal"
-      "slack"
-    ];
     # Note: need to be signed into the Mac App Store for mas to successfully
     # install and upgrade applications. Unfortunately apps removed from this
     # option will not be uninstalled automatically even if


### PR DESCRIPTION
Apps are now installed either by default or through the self-service app